### PR TITLE
Add Arcane Ascension privacy policy and app-ads.txt

### DIFF
--- a/app-ads.txt
+++ b/app-ads.txt
@@ -1,0 +1,1 @@
+google.com, pub-3354701291265180, DIRECT, f08c47fec0942fa0

--- a/app-ads.txt
+++ b/app-ads.txt
@@ -1,1 +1,0 @@
-google.com, pub-3354701291265180, DIRECT, f08c47fec0942fa0

--- a/arcane-ascension/privacy.html
+++ b/arcane-ascension/privacy.html
@@ -181,7 +181,7 @@
 
   <h2>Contact</h2>
   <p>Questions or requests about this policy or your data:<br>
-    <strong>Ian Murray</strong> — ianstanfordmurray@gmail.com<br>
+    <strong>Ian Murray</strong> — contact@ian-murray.com<br>
     Website: <a href="https://ian-murray.com">ian-murray.com</a>
   </p>
 </body>

--- a/arcane-ascension/privacy.html
+++ b/arcane-ascension/privacy.html
@@ -1,0 +1,189 @@
+<!DOCTYPE html>
+<html lang="en">
+
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <meta name="description" content="Privacy policy for Arcane Ascension, a turn-based hex tactics game.">
+  <title>Privacy Policy — Arcane Ascension</title>
+  <style>
+    :root {
+      color-scheme: dark;
+    }
+
+    body {
+      background: #15131F;
+      color: #EAE6F5;
+      font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, sans-serif;
+      line-height: 1.65;
+      max-width: 720px;
+      margin: 0 auto;
+      padding: 2rem 1.25rem 4rem;
+    }
+
+    h1,
+    h2 {
+      font-family: Georgia, "Times New Roman", serif;
+      color: #F2C14E;
+    }
+
+    h1 {
+      font-size: 1.9rem;
+      margin-bottom: 0.25rem;
+    }
+
+    h2 {
+      font-size: 1.25rem;
+      margin-top: 2.2rem;
+    }
+
+    a {
+      color: #A78BFF;
+    }
+
+    .meta {
+      color: #9A93B0;
+      font-size: 0.95rem;
+      margin-bottom: 2rem;
+    }
+
+    .tldr {
+      background: #221E33;
+      border-left: 4px solid #7B5CFF;
+      padding: 0.9rem 1.1rem;
+      border-radius: 6px;
+    }
+
+    ul {
+      padding-left: 1.4rem;
+    }
+
+    li {
+      margin: 0.35rem 0;
+    }
+  </style>
+</head>
+
+<body>
+  <h1>Arcane Ascension — Privacy Policy</h1>
+  <p class="meta">Effective date: July 2, 2026 · Last updated: July 2, 2026</p>
+
+  <p>This privacy policy describes how Arcane Ascension (&ldquo;the app&rdquo;,
+    &ldquo;we&rdquo;) handles information when you play the game on Android, iOS,
+    or the web. Arcane Ascension is developed by Ian Murray
+    (&ldquo;the developer&rdquo;).</p>
+
+  <p class="tldr">The short version: the game has no accounts and never asks
+    for your name, email, or contact details. Your game progress stays on your
+    device. The app uses Google services for anonymous usage analytics, crash
+    reporting, and — on Android and iOS only — optional rewarded ads.</p>
+
+  <h2>Information we collect</h2>
+  <p>We do not collect any information that directly identifies you. The app
+    includes the following third-party services, which collect limited data
+    automatically:</p>
+
+  <h2>Google Analytics for Firebase</h2>
+  <p>Collects anonymous usage data so we can understand how the game is played
+    and improve it — for example: matches started and finished, game settings
+    used, spells cast, feature usage, session length, approximate region
+    (derived from IP address, which is not retained), device model, and
+    operating system version. This data is associated with a randomly generated
+    app-instance identifier, not with you.</p>
+
+  <h2>Firebase Crashlytics</h2>
+  <p>Collects crash reports and diagnostics (stack traces, device state at the
+    time of a crash, device model, OS version) so we can find and fix bugs.</p>
+
+  <h2>Google AdMob (Android and iOS only)</h2>
+  <p>The mobile app can show an optional, rewarded video ad — only when you
+    choose to watch one. AdMob may collect device advertising identifiers and
+    ad-interaction data to serve and measure ads.</p>
+  <ul>
+    <li><strong>In the European Economic Area, the UK, and Switzerland:</strong>
+      a consent form is shown before any ads are requested. If you do not
+      consent to personalized ads, ads are either not shown or shown on a
+      non-personalized basis.</li>
+    <li><strong>On iOS:</strong> personalized ads are only enabled if you allow
+      tracking via Apple&rsquo;s App Tracking Transparency prompt. If you
+      decline, ads are non-personalized.</li>
+    <li>The web version of the game shows no ads.</li>
+  </ul>
+
+  <h2>Information stored on your device</h2>
+  <p>Game progress (unlocks, statistics, achievements, in-progress matches,
+    settings) is stored locally on your device and, on Android, may be backed up
+    via Google Block Store so progress can transfer to a new device. We cannot
+    access this data; it never reaches our servers.</p>
+
+  <h2>How we use information</h2>
+  <ul>
+    <li>To understand feature usage and improve the game</li>
+    <li>To find and fix crashes and bugs</li>
+    <li>To serve and measure the optional rewarded ads (mobile only)</li>
+    <li>To measure aggregate game balance (e.g., which spells are over- or
+      under-used)</li>
+  </ul>
+  <p>We do not sell your data. We do not use the data for any purpose other
+    than those listed above.</p>
+
+  <h2>Data sharing</h2>
+  <p>Data collected by the services above is processed by Google LLC under
+    their own privacy policies:</p>
+  <ul>
+    <li><a href="https://policies.google.com/privacy">Google Privacy Policy</a></li>
+    <li><a href="https://policies.google.com/technologies/partner-sites">How Google uses data from partner apps</a></li>
+    <li><a href="https://support.google.com/admob/answer/6128543">AdMob data usage</a></li>
+  </ul>
+  <p>We do not share data with anyone else.</p>
+
+  <h2>Data retention</h2>
+  <p>Analytics and crash data are retained by Google Firebase per their
+    standard retention controls (user-level analytics data is retained for a
+    limited period, then aggregated). Local game data remains on your device
+    until you delete the app or reset progress in the app&rsquo;s settings.</p>
+
+  <h2>Your rights and choices</h2>
+  <ul>
+    <li><strong>Ads consent (EEA/UK/CH):</strong> you can change your ads
+      consent choice at any time from the game&rsquo;s settings.</li>
+    <li><strong>iOS tracking:</strong> iOS Settings → Privacy &amp; Security →
+      Tracking.</li>
+    <li><strong>Android ads personalization:</strong> Android Settings →
+      Privacy → Ads (reset or delete your advertising ID).</li>
+    <li><strong>Deletion:</strong> deleting the app removes all locally stored
+      game data. Because analytics data is not tied to your identity, we cannot
+      look up or delete individual records on request — but you can ask us to
+      delete data associated with your app instance if you provide the
+      app-instance ID.</li>
+    <li>Depending on your jurisdiction (e.g., GDPR in the EU, CCPA/CPRA in
+      California), you may have additional rights such as access, correction,
+      deletion, and objection to processing. Contact us to exercise them.</li>
+  </ul>
+
+  <h2>Children</h2>
+  <p>Arcane Ascension is not directed at children under 13 (or the equivalent
+    minimum age in your jurisdiction), and we do not knowingly collect personal
+    information from children. Ads served through AdMob use Google&rsquo;s
+    standard protections; if you believe a child has provided personal
+    information through the app, contact us and we will address it.</p>
+
+  <h2>Security</h2>
+  <p>The app makes no network requests other than those made by the Google
+    services described above, which use encrypted (HTTPS) connections. Locally
+    stored progress uses your device&rsquo;s standard app storage protections
+    (and the platform keychain/keystore where applicable).</p>
+
+  <h2>Changes to this policy</h2>
+  <p>If we make material changes, we will update this page and the effective
+    date above. Continued use of the app after changes take effect constitutes
+    acceptance of the revised policy.</p>
+
+  <h2>Contact</h2>
+  <p>Questions or requests about this policy or your data:<br>
+    <strong>Ian Murray</strong> — ianstanfordmurray@gmail.com<br>
+    Website: <a href="https://ian-murray.com">ian-murray.com</a>
+  </p>
+</body>
+
+</html>

--- a/index.html
+++ b/index.html
@@ -61,7 +61,7 @@
     <div id="lead">
         <div id="lead-content">
             <h1>Ian Murray</h1>
-            <h2>Senior Software Engineer</h2>
+            <h2>Staff Full Stack Engineer</h2>
             <img src="http://res.cloudinary.com/ismurray/image/upload/v1523215450/headshot1.jpg" class="rounded-circle headshot" alt="Ian Murray Headshot">
             <a href="images/IanMurrayResume-2020-09-17.pdf" download="IanMurrayResume-2020-09-17.pdf" class="btn-rounded-white">Download Resume</a>
         </div>
@@ -303,9 +303,24 @@
         <h2 class="heading">Experience</h2>
         <div id="experience-timeline">
 
-          <div data-date="June 2019 – Present">
+          <div data-date="October 2022 – Present">
+              <h3>BetterUp (Remote)</h3>
+              <h4>Staff Full Stack Engineer</h4>
+          </div>
+
+          <div data-date="October 2021 – October 2022">
+              <h3>SpotOn (Remote)</h3>
+              <h4>Staff Engineer</h4>
+          </div>
+
+          <div data-date="October 2020 – October 2021">
+              <h3>SpotOn (Remote)</h3>
+              <h4>Senior Software Engineer, Tech Lead</h4>
+          </div>
+
+          <div data-date="June 2019 – September 2020">
               <h3>SpotOn (Ann Arbor, MI)</h3>
-              <h4>Back-End Software Engineer</h4>
+              <h4>Full-Stack Developer</h4>
               <ul>
                 <li>Developed greenfield Golang microservices, APIs, and ETL pipelines</li>
                 <li>Contributed to a Golang/Mongo/JS Restaurant POS software service</li>
@@ -316,12 +331,16 @@
               </ul>
           </div>
 
-          <div data-date="May 2019 – Present">
+          <div data-date="May 2019 – November 2020">
               <h3>Gamer Sensei (Remote)</h3>
               <h4>Consulting Software Engineer</h4>
+              <ul>
+                <li>Identified API endpoints causing significant memory consumption issues, then refactored and optimized the queries used in these endpoints, resulting in an 80% reduction in request/response time for the most affected users, and a 50% reduction in application memory usage during periods of typical load</li>
+                <li>Implemented several platform-wide security measures including automated account-locking, rate-limiting, and IP block/allow-lists to protect against brute-force attacks and referral abuse</li>
+              </ul>
           </div>
 
-          <div data-date="May 2018 – March 2019">
+          <div data-date="May 2018 – May 2019">
               <h3>Gamer Sensei (Boston, MA)</h3>
               <h4>Back-End Software Engineer</h4>
               <ul>
@@ -409,7 +428,7 @@
           <div class="col-lg-3 col-md-6 col-sm-6 mr-auto text-center">
             <i class="fa fa-envelope-o fa-3x mb-3 sr-contact"></i>
             <p>
-              <a href="mailto:ismurray@bu.edu">ismurray@bu.edu</a>
+              <a href="mailto:contact@ian-murray.com">contact@ian-murray.com</a>
             </p>
           </div>
           <div class="col-lg-3 col-md-6 col-sm-6 mr-auto text-center">


### PR DESCRIPTION
## Summary
- Adds the Arcane Ascension privacy policy at `arcane-ascension/privacy.html` → serves at `https://ian-murray.com/arcane-ascension/privacy.html`
- Adds `app-ads.txt` at the repo root → serves at `https://ian-murray.com/app-ads.txt`. Required for AdMob inventory verification; ian-murray.com will be listed as the developer website on the app store listings, and AdMob crawls that domain for this file. (It declares the app's ad sellers — it does not imply ads on this site.)
- Contact email updated to contact@ian-murray.com (header mailto + privacy policy)
- Experience section refreshed from LinkedIn: BetterUp (Staff Full Stack Engineer, Oct 2022–present), SpotOn promotions (Full-Stack Developer → Senior SWE/Tech Lead → Staff Engineer), Gamer Sensei consulting dates + bullets; headline updated to Staff Full Stack Engineer

## After merging
- Verify both URLs load:
  - https://ian-murray.com/arcane-ascension/privacy.html
  - https://ian-murray.com/app-ads.txt