### PR TITLE
Privacy policy: document the analytics opt-out setting

### DIFF
--- a/arcane-ascension/privacy.html
+++ b/arcane-ascension/privacy.html
@@ -145,6 +145,9 @@
 
   <h2>Your rights and choices</h2>
   <ul>
+    <li><strong>Analytics opt-out:</strong> you can turn off &ldquo;Share
+      anonymous usage data&rdquo; in the game&rsquo;s settings at any time;
+      this disables analytics and crash reporting for your device.</li>
     <li><strong>Ads consent (EEA/UK/CH):</strong> you can change your ads
       consent choice at any time from the game&rsquo;s settings.</li>
     <li><strong>iOS tracking:</strong> iOS Settings → Privacy &amp; Security →


### PR DESCRIPTION
The game now has a 'Share anonymous usage data' toggle in settings (default on) that disables Firebase Analytics + Crashlytics. This adds the corresponding bullet to 'Your rights and choices'. Merge alongside/after the app release that ships the toggle (any time is fine — the setting exists in the codebase now).

Made with [Cursor](https://cursor.com)