### PR TITLE
Point game links at play.arcane-ascension.com; canonicalise to the new domain

### DIFF
--- a/arcane-ascension/index.html
+++ b/arcane-ascension/index.html
@@ -211,6 +211,7 @@
       padding: 2rem 1rem 3rem;
     }
   </style>
+  <link rel="canonical" href="https://arcane-ascension.com/">
 </head>
 
 <body>
@@ -219,7 +220,7 @@
     <h1><span class="arcane">ARCANE</span> <span class="ascension">ASCENSION</span></h1>
     <p class="tagline">Turn-based hex tactics</p>
     <div class="stores">
-      <a class="store-btn primary" href="https://arcane-ascension.com" target="_blank" rel="noopener">
+      <a class="store-btn primary" href="https://play.arcane-ascension.com" target="_blank" rel="noopener">
         ▶ Play free in your browser
       </a>
       <!-- Flip to a live link once approved:
@@ -325,7 +326,7 @@
         </p>
         <p>
           <a href="/arcane-ascension/privacy.html">Privacy policy</a> ·
-          <a href="https://arcane-ascension.com" target="_blank" rel="noopener">Play on the web</a>
+          <a href="https://play.arcane-ascension.com" target="_blank" rel="noopener">Play on the web</a>
         </p>
       </div>
     </section>

--- a/arcane-ascension/index.html
+++ b/arcane-ascension/index.html
@@ -219,7 +219,7 @@
     <h1><span class="arcane">ARCANE</span> <span class="ascension">ASCENSION</span></h1>
     <p class="tagline">Turn-based hex tactics</p>
     <div class="stores">
-      <a class="store-btn primary" href="https://arcane-ascension-game.web.app" target="_blank" rel="noopener">
+      <a class="store-btn primary" href="https://arcane-ascension.com" target="_blank" rel="noopener">
         ▶ Play free in your browser
       </a>
       <!-- Flip to a live link once approved:
@@ -325,7 +325,7 @@
         </p>
         <p>
           <a href="/arcane-ascension/privacy.html">Privacy policy</a> ·
-          <a href="https://arcane-ascension-game.web.app" target="_blank" rel="noopener">Play on the web</a>
+          <a href="https://arcane-ascension.com" target="_blank" rel="noopener">Play on the web</a>
         </p>
       </div>
     </section>

--- a/arcane-ascension/privacy.html
+++ b/arcane-ascension/privacy.html
@@ -30,6 +30,7 @@
     ul { padding-left: 1.4rem; }
     li { margin: 0.35rem 0; }
   </style>
+  <link rel="canonical" href="https://arcane-ascension.com/privacy.html">
 </head>
 <body>
   <h1>Arcane Ascension — Privacy Policy</h1>

--- a/arcane-ascension/privacy.html
+++ b/arcane-ascension/privacy.html
@@ -115,7 +115,7 @@
   games. Records of finished matches remain in other players&rsquo; match
   histories; once your account is deleted they can no longer be linked to
   anyone. Full instructions:
-  <a href="https://arcane-ascension-game.web.app/delete-account.html">delete-account page</a>.</p>
+  <a href="https://arcane-ascension.com/delete-account.html">delete-account page</a>.</p>
 
   <h2>Information stored on your device</h2>
   <p>Game progress (unlocks, statistics, achievements, in-progress matches,
@@ -165,7 +165,7 @@
     Privacy → Ads (reset or delete your advertising ID).</li>
     <li><strong>Online account deletion:</strong> delete your online account
     in-app from the online lobby, or see the
-    <a href="https://arcane-ascension-game.web.app/delete-account.html">delete-account page</a> for details and a
+    <a href="https://arcane-ascension.com/delete-account.html">delete-account page</a> for details and a
     contact route if you no longer have the app.</li>
     <li><strong>Deletion:</strong> deleting the app removes all locally stored
     game data. Because analytics data is not tied to your identity, we cannot

--- a/arcane-ascension/privacy.html
+++ b/arcane-ascension/privacy.html
@@ -30,7 +30,7 @@
     ul { padding-left: 1.4rem; }
     li { margin: 0.35rem 0; }
   </style>
-  <link rel="canonical" href="https://arcane-ascension.com/privacy.html">
+  <link rel="canonical" href="https://arcane-ascension.com/privacy">
 </head>
 <body>
   <h1>Arcane Ascension — Privacy Policy</h1>
@@ -116,7 +116,7 @@
   games. Records of finished matches remain in other players&rsquo; match
   histories; once your account is deleted they can no longer be linked to
   anyone. Full instructions:
-  <a href="https://arcane-ascension.com/delete-account.html">delete-account page</a>.</p>
+  <a href="https://arcane-ascension.com/delete-account">delete-account page</a>.</p>
 
   <h2>Information stored on your device</h2>
   <p>Game progress (unlocks, statistics, achievements, in-progress matches,
@@ -166,7 +166,7 @@
     Privacy → Ads (reset or delete your advertising ID).</li>
     <li><strong>Online account deletion:</strong> delete your online account
     in-app from the online lobby, or see the
-    <a href="https://arcane-ascension.com/delete-account.html">delete-account page</a> for details and a
+    <a href="https://arcane-ascension.com/delete-account">delete-account page</a> for details and a
     contact route if you no longer have the app.</li>
     <li><strong>Deletion:</strong> deleting the app removes all locally stored
     game data. Because analytics data is not tied to your identity, we cannot

--- a/index.html
+++ b/index.html
@@ -151,7 +151,7 @@
                         <p>Shared Dart rules engine across all platforms with deterministic replays, a daily seeded challenge, local pass-and-play multiplayer, and a sandbox scenario editor with cross-platform share codes</p>
                         <p>Shipped as a PWA on Firebase Hosting with content-hashed deploys, plus store releases signed and delivered through Play Console and App Store Connect</p>
                       </ul>
-                      <p><a href="/arcane-ascension/">Game Page</a> · <a href="https://arcane-ascension.com" target="_blank">Play in Browser</a></p>
+                      <p><a href="/arcane-ascension/">Game Page</a> · <a href="https://play.arcane-ascension.com" target="_blank">Play in Browser</a></p>
                   </div>
                   <!-- End .project-info -->
                 </div>

--- a/index.html
+++ b/index.html
@@ -151,7 +151,7 @@
                         <p>Shared Dart rules engine across all platforms with deterministic replays, a daily seeded challenge, local pass-and-play multiplayer, and a sandbox scenario editor with cross-platform share codes</p>
                         <p>Shipped as a PWA on Firebase Hosting with content-hashed deploys, plus store releases signed and delivered through Play Console and App Store Connect</p>
                       </ul>
-                      <p><a href="/arcane-ascension/">Game Page</a> · <a href="https://arcane-ascension-game.web.app" target="_blank">Play in Browser</a></p>
+                      <p><a href="/arcane-ascension/">Game Page</a> · <a href="https://arcane-ascension.com" target="_blank">Play in Browser</a></p>
                   </div>
                   <!-- End .project-info -->
                 </div>


### PR DESCRIPTION
Swaps every link to the game's web build from the Firebase-generated hostname `arcane-ascension-game.web.app` to the new custom domain `arcane-ascension.com` (Cloudflare DNS → Firebase Hosting).

**Draft on purpose — do not merge until Firebase Hosting shows the domain as Connected.** Merging here deploys GitHub Pages immediately, and until the domain provisions these links would point at a host that doesn't resolve. The old `.web.app` / `.firebaseapp.com` origins stay live permanently, so there's no rush and no breakage either way.

### Changes

| File | What |
| --- | --- |
| `index.html` | "Play in Browser" link in the portfolio project card |
| `arcane-ascension/index.html` | hero "Play" button + in-page "Play on the web" link |
| `arcane-ascension/privacy.html` | both delete-account links (`delete-account.html` ships with the web build, so it serves from the new domain too) |

### Deliberately unchanged

- **Marketing URL for the stores stays `ian-murray.com/arcane-ascension/`.** That page is static HTML and SEO-readable; `arcane-ascension.com` serves the Flutter build, which crawlers see as an empty canvas.
- `app-ads.txt` stays canonical at the site root here — AdMob crawls the developer-website domain from the store listings, which still point at `ian-murray.com`.

Full cutover runbook, including the Cloudflare/Firebase DNS steps and the downstream console work (Firebase Auth authorized domains, GA4 stream URL, AdSense site), lives in the game repo at `docs/harness/plans/2026-07-07-services-clickops-playbook.md` §7.

🤖 Generated with [Claude Code](https://claude.com/claude-code)