### PR TITLE
Pages hardening: stop publishing repo files, add 404, real README

### DIFF
--- a/404.html
+++ b/404.html
@@ -1,0 +1,25 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="utf-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1">
+  <title>Page not found — Ian Murray</title>
+  <meta name="robots" content="noindex">
+  <style>
+    body {
+      background: #101217; color: #e8eaf0; min-height: 100vh; margin: 0;
+      display: flex; align-items: center; justify-content: center;
+      font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, Helvetica, Arial, sans-serif;
+      text-align: center;
+    }
+    a { color: #6d7cff; }
+    p { color: #9aa2b4; }
+  </style>
+</head>
+<body>
+  <div>
+    <h1>404</h1>
+    <p>That page doesn't exist. <a href="/">Back to ian-murray.com</a></p>
+  </div>
+</body>
+</html>

--- a/README.md
+++ b/README.md
@@ -1,21 +1,78 @@
-# About Me
+# ian-murray.com — personal portfolio
 
-Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum.
+Personal portfolio site for Ian Murray, served at
+[ian-murray.com](https://ian-murray.com) via **GitHub Pages** from this
+repo's default branch. The `CNAME` file is what binds the custom domain;
+DNS for `ian-murray.com` is at GoDaddy and points at GitHub's Pages IPs
+(`185.199.108–111.153`).
 
-## Skills
+> Originally forked from
+> [RyanFitzgerald/devportfolio](https://github.com/RyanFitzgerald/devportfolio).
+> The `upstream` remote still points there — **be careful with `gh pr
+> create`**, which defaults to a fork's parent. Run
+> `gh repo set-default ismurray/ismurray.github.io` in any fresh clone.
 
-Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur. 
+## Table of contents
 
-## Contact info
+- [Layout](#layout)
+- [Local development](#local-development)
+- [What is published](#what-is-published)
+- [Related sites](#related-sites)
 
-Lorem ipsum dolor sit amet,
-consectetur adipiscing elit,
-sed do eiusmod tempor incididunt ut labore et dolore magna aliqua.
+## Layout
 
-## Resume view & download
+| Path | Purpose |
+|---|---|
+| `index.html` | The portfolio page itself (single page) |
+| `404.html` | Custom not-found page (GitHub Pages serves it automatically) |
+| `arcane-ascension/` | Landing page + privacy policy for the Arcane Ascension game |
+| `app-ads.txt` | AdMob authorized-sellers declaration — **must stay at the site root** |
+| `css/`, `js/`, `libs/`, `images/` | Compiled/vendored front-end assets that ship with the site |
+| `scss/` | Sass **source** for `css/` — not published |
+| `gulpfile.js`, `package.json` | Build tooling — not published |
+| `CNAME` | Binds `ian-murray.com` to this Pages site |
+| `_config.yml` | Jekyll config; its only real job is the `exclude` list |
 
-Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat.
+## Local development
 
-## Projects
+```bash
+npm install
+npm run watch     # gulp: compiles scss/ -> css/ and minifies js/
+```
 
-Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum.
+Then open `index.html` directly, or serve the directory with
+`python3 -m http.server`.
+
+Committing compiled `css/` and `js/` is intentional — GitHub Pages does not
+run the gulp build, so the compiled output has to be in the repo.
+
+## What is published
+
+GitHub Pages runs Jekyll and publishes **everything not excluded** by
+`_config.yml`. That list is load-bearing: before it existed,
+`ian-murray.com/README.md`, `/package.json` and `/gulpfile.js` were all
+publicly fetchable.
+
+If you add tooling, config, or notes to the repo root, add them to
+`exclude` in `_config.yml` too. Verify with:
+
+```bash
+curl -sSI https://ian-murray.com/README.md      # expect 404
+curl -sSI https://ian-murray.com/app-ads.txt    # expect 200 — AdMob crawls this
+curl -sS   https://ian-murray.com/no-such-page | head -5   # expect 404.html
+```
+
+`app-ads.txt` matters: AdMob crawls the developer-website domain listed on
+the Play Console and App Store Connect listings, and the file must be at
+the domain root — a subdirectory does not count.
+
+## Related sites
+
+| Site | Repo | Host |
+|---|---|---|
+| [ian-murray.com](https://ian-murray.com) | this one | GitHub Pages |
+| [ismurray.com](https://ismurray.com) (ismurray LLC) | `ismurray/ismurray-com` | Cloudflare Workers |
+| [arcane-ascension.com](https://arcane-ascension.com) (the game) | `antiyoy_but_with_wizards` | Firebase Hosting |
+
+The game's privacy policy is mirrored in three places (here, the LLC site,
+and the game's web build). Keep them in sync when it changes.

--- a/_config.yml
+++ b/_config.yml
@@ -1,0 +1,30 @@
+# Jekyll config for GitHub Pages (ian-murray.com).
+#
+# This file exists for one reason: `exclude`. GitHub Pages runs Jekyll over
+# this repo and publishes everything it doesn't exclude, so without this the
+# repo's own tooling and docs were served as part of the website —
+# ian-murray.com/README.md, /package.json and /gulpfile.js all returned 200.
+#
+# NOTE: setting `exclude` REPLACES Jekyll's built-in default list, so the
+# defaults (Gemfile, node_modules, vendor/…) are repeated here rather than
+# inherited.
+exclude:
+  # Repo docs and metadata — not part of the site.
+  - README.md
+  - LICENSE.md
+  # Build tooling. `scss/` is the source for `css/`; only the compiled CSS
+  # should ship.
+  - gulpfile.js
+  - package.json
+  - package-lock.json
+  - scss/
+  # Jekyll defaults, restated because `exclude` overrides them.
+  - Gemfile
+  - Gemfile.lock
+  - node_modules/
+  - vendor/bundle/
+  - vendor/cache/
+  - vendor/gems/
+  - vendor/ruby/
+  - .sass-cache/
+  - .jekyll-cache/


### PR DESCRIPTION
GitHub Pages runs Jekyll and publishes **everything it doesn't exclude**, so this repo's own tooling and docs were being served as part of the website:

```
ian-murray.com/README.md     → 200
ian-murray.com/package.json  → 200
ian-murray.com/gulpfile.js   → 200
ian-murray.com/LICENSE.md    → 200
```

The README was still the upstream devportfolio template's **lorem ipsum**, publicly readable on the domain.

### Changes

- **`_config.yml`** (new) — an `exclude` list covering repo docs, the gulp/npm tooling, and `scss/` (the Sass source for the compiled `css/` that *does* ship). Note that setting `exclude` **replaces** Jekyll's built-in default list rather than extending it, so the defaults (`Gemfile`, `node_modules/`, `vendor/…`) are restated.
- **`404.html`** (new) — custom not-found page instead of GitHub's generic one, styled to match `ismurray.com`'s.
- **`README.md`** — rewritten to describe this site: layout, the local gulp build, what does and doesn't get published, and why `app-ads.txt` must stay at the root. Also documents the `upstream` remote pointing at `RyanFitzgerald/devportfolio`, which makes `gh pr create` default to the wrong repo.

### Verify after merge

```bash
curl -sSI https://ian-murray.com/README.md      # expect 404 (was 200)
curl -sSI https://ian-murray.com/package.json   # expect 404 (was 200)
curl -sSI https://ian-murray.com/app-ads.txt    # expect 200 — MUST stay reachable
curl -sS   https://ian-murray.com/no-such-page | head -5   # expect the new 404 page
curl -sSI https://ian-murray.com/               # expect 200
curl -sSI https://ian-murray.com/arcane-ascension/  # expect 200
```

`app-ads.txt` and `/arcane-ascension/` are the two things that must not regress — AdMob crawls the former, and the latter is the Marketing URL on the store listings.

### Risk

Low, but non-zero: adding `_config.yml` configures Jekyll rather than enabling it (Pages already runs Jekyll here — that's why `scss/style.scss` already 404s). The change only removes files from the output. Still worth running the checks above once Pages redeploys.

Independent of #10, which stays blocked on the domain migration.

🤖 Generated with [Claude Code](https://claude.com/claude-code)