### PR TITLE
Link arcane-ascension.com, relabel it, and add ismurray LLC

### DIFF
--- a/index.html
+++ b/index.html
@@ -87,7 +87,8 @@
                 <div class="col-md-8">
                     <p>I'm a tenacious developer with a background in biochemical research and a passion for solving tough problems.</p><br>
                     <p>I had my first introduction to software development through a Bioinformatics course I took while studying Biochemistry at Boston University. It was just a taste of Python, but I was immediately hooked. Since then, I’ve had a chance to build applications for biochemical research, ecommerce, and restaurant point of sale.</p><br>
-                    <p>My experience in research instilled in me a relentless and detail-oriented approach to problem solving. In fact, some of my favorite moments in the development process come from hitting a wall. There’s a unique sense of satisfaction I get from pulling out a hammer and some nails to start building a ladder. I’m eager to bring my determination, and my passion for learning to a forward-thinking engineering team where I can help to drive growth through thoughtful, scalable solutions.</p>
+                    <p>My experience in research instilled in me a relentless and detail-oriented approach to problem solving. In fact, some of my favorite moments in the development process come from hitting a wall. There’s a unique sense of satisfaction I get from pulling out a hammer and some nails to start building a ladder. I’m eager to bring my determination, and my passion for learning to a forward-thinking engineering team where I can help to drive growth through thoughtful, scalable solutions.</p><br>
+                    <p>Outside of my day job, I run <a href="https://ismurray.com" target="_blank" rel="noopener">ismurray LLC</a>, an independent software and game development studio, where I designed and shipped <a href="https://arcane-ascension.com" target="_blank" rel="noopener">Arcane Ascension</a> end to end — from the rules engine to the store listings.</p>
                 </div>
             </div>
         </div>
@@ -151,7 +152,7 @@
                         <p>Shared Dart rules engine across all platforms with deterministic replays, a daily seeded challenge, local pass-and-play multiplayer, and a sandbox scenario editor with cross-platform share codes</p>
                         <p>Shipped as a PWA on Firebase Hosting with content-hashed deploys, plus store releases signed and delivered through Play Console and App Store Connect</p>
                       </ul>
-                      <p><a href="/arcane-ascension/">Game Page</a> · <a href="https://play.arcane-ascension.com" target="_blank">Play in Browser</a></p>
+                      <p><a href="https://arcane-ascension.com" target="_blank" rel="noopener">Official site</a> · <a href="https://play.arcane-ascension.com" target="_blank" rel="noopener">Play in Browser</a> · <a href="https://ismurray.com" target="_blank" rel="noopener">Published by ismurray LLC</a></p>
                   </div>
                   <!-- End .project-info -->
                 </div>
@@ -323,6 +324,16 @@
     <div id="experience" class="background-alt">
         <h2 class="heading">Experience</h2>
         <div id="experience-timeline">
+
+          <div data-date="July 2026 – Present">
+              <h3><a href="https://ismurray.com" target="_blank" rel="noopener">ismurray LLC</a> (Raleigh, NC)</h3>
+              <h4>Founder &amp; Sole Engineer</h4>
+              <ul>
+                <li>Founded a single-member North Carolina LLC as an independent software and video game development studio</li>
+                <li>Designed, built, and published <a href="https://arcane-ascension.com" target="_blank" rel="noopener">Arcane Ascension</a>, a cross-platform turn-based strategy game shipping to iOS, Android, and web from one Flutter/Dart codebase</li>
+                <li>Handled the full release pipeline solo: signing and store submission for both mobile platforms, privacy and data-safety compliance, consent-gated analytics, and web deploys behind a size-budgeted CI gate</li>
+              </ul>
+          </div>
 
           <div data-date="October 2022 – Present">
               <h3>BetterUp (Remote)</h3>

--- a/index.html
+++ b/index.html
@@ -88,7 +88,7 @@
                     <p>I'm a tenacious developer with a background in biochemical research and a passion for solving tough problems.</p><br>
                     <p>I had my first introduction to software development through a Bioinformatics course I took while studying Biochemistry at Boston University. It was just a taste of Python, but I was immediately hooked. Since then, I’ve had a chance to build applications for biochemical research, ecommerce, and restaurant point of sale.</p><br>
                     <p>My experience in research instilled in me a relentless and detail-oriented approach to problem solving. In fact, some of my favorite moments in the development process come from hitting a wall. There’s a unique sense of satisfaction I get from pulling out a hammer and some nails to start building a ladder. I’m eager to bring my determination, and my passion for learning to a forward-thinking engineering team where I can help to drive growth through thoughtful, scalable solutions.</p><br>
-                    <p>Outside of my day job, I run <a href="https://ismurray.com" target="_blank" rel="noopener">ismurray LLC</a>, an independent software and game development studio, where I designed and shipped <a href="https://arcane-ascension.com" target="_blank" rel="noopener">Arcane Ascension</a> end to end — from the rules engine to the store listings.</p>
+                    <p>Outside of my day job, I run <a href="https://ismurray.com" target="_blank" rel="noopener">ismurray LLC</a>, an independent software and game development studio.</p>
                 </div>
             </div>
         </div>
@@ -327,11 +327,10 @@
 
           <div data-date="July 2026 – Present">
               <h3><a href="https://ismurray.com" target="_blank" rel="noopener">ismurray LLC</a> (Raleigh, NC)</h3>
-              <h4>Founder &amp; Sole Engineer</h4>
+              <h4>Founder</h4>
               <ul>
-                <li>Founded a single-member North Carolina LLC as an independent software and video game development studio</li>
-                <li>Designed, built, and published <a href="https://arcane-ascension.com" target="_blank" rel="noopener">Arcane Ascension</a>, a cross-platform turn-based strategy game shipping to iOS, Android, and web from one Flutter/Dart codebase</li>
-                <li>Handled the full release pipeline solo: signing and store submission for both mobile platforms, privacy and data-safety compliance, consent-gated analytics, and web deploys behind a size-budgeted CI gate</li>
+                <li>Founded <a href="https://ismurray.com" target="_blank" rel="noopener">ismurray LLC</a>, an independent software and video game development studio</li>
+                <li>Independent game development, alongside software development and consulting services</li>
               </ul>
           </div>
 


### PR DESCRIPTION
### The bug

The Arcane Ascension project card linked **`/arcane-ascension/`** — this site's *own copy* of the landing page — rather than `arcane-ascension.com`, which is now the real one. PR #10 repointed the *play* links but left this pointing inward.

The local copy stays in the repo on purpose: the store listings' Marketing URL and the AdMob consent message's privacy URL still point at `ian-murray.com/arcane-ascension/`, so those files have to keep resolving. But nothing should *link* there anymore.

### Naming

`Game Page` → **`Official site`**. Sitting next to "Play in Browser", "Game Page" read as a near-synonym for the playable web app. `Official site` · `Play in Browser` makes the distinction obvious at a glance.

Alternatives if you'd rather: `arcane-ascension.com` (bare domain — unmissable, doubles as domain marketing) or `About the game`. One-line change either way.

### ismurray LLC

Added in three places:

- **Experience timeline** — `July 2026 – Present`, *Founder & Sole Engineer*, matching the entity's own description as an independent software and video game development studio (formation date and description from the LLC's company-info record).
- **About Me** — a closing paragraph linking the studio and the game.
- **Project card** — "Published by ismurray LLC".

All three link to `ismurray.com`.

**Please read the Experience bullets before merging** — I wrote them from the company record and the repo's release history, but this is your professional bio and you should be the one to sign off on the framing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)